### PR TITLE
ci: try larger runner for lotus-localnet-multiarch build

### DIFF
--- a/.github/workflows/lotus-localnet-multiarch.yml
+++ b/.github/workflows/lotus-localnet-multiarch.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   run-build-and-push-oci-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
I skimmed through https://github.com/filecoin-project/filecoin-fvm-localnet/actions/runs/4840483156 and it looks like it failed with OOM.

We can try GitHub hosted large runners.

`ubuntu-latest-4-cores` has 4-cores · 16 GB RAM · 150 GB SSD. There's also `ubuntu-latest-8-cores` with 8-cores · 32 GB RAM · 300 GB SSD, and `ubuntu-latest-16-cores` with 16-cores · 64 GB RAM · 600 GB SSD. And we can set up `ubuntu-latest-32-cores` and `ubuntu-latest-64-cores` ones 😮 

If it turns out we need more customisation, we can turn to our own self-hosted runners - https://github.com/pl-strflt/tf-aws-gh-runner. I'd be more than happy to set it up but I think it makes sense to try hosted first. 